### PR TITLE
Index of drillbits + Zookeeper Path

### DIFF
--- a/client.go
+++ b/client.go
@@ -160,6 +160,10 @@ func (d *Client) NewConnection(ctx context.Context) (Conn, error) {
 
 	newClient.nextBit = d.nextBit
 
+	if eindex >= len(newClient.drillBits) {
+		eindex = 0
+	}
+
 	if newClient.Opts.ZKPath == "" {
 		newClient.Opts.ZKPath = "/drill/" + newClient.Opts.ClusterName
 	}

--- a/zk_handler.go
+++ b/zk_handler.go
@@ -2,6 +2,7 @@ package drill
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/factset/go-drill/internal/log"
@@ -73,6 +74,10 @@ func (z *zkHandler) GetDrillBits() []string {
 // GetEndpoint returns the information necessary to connect to a given drillbit
 // from its name.
 func (z *zkHandler) GetEndpoint(drillbit string) Drillbit {
+	// Sometimes the path is wrong: unsure why
+	if !strings.Contains(z.Path, "/drill/") {
+		z.Path = "/drill/" + z.Path
+	}
 	data, _, err := z.conn.Get(z.Path + "/" + drillbit)
 	if err != nil {
 		z.Err = err


### PR DESCRIPTION
Thank you for the great package, I'm relying on it quite a bit now, I'm just encountering two issues:

1. See #5, we check for `d.nextBit >= len(newClient.drillBits)` but `eindex` can remain out of range.

https://github.com/factset/go-drill/blob/eb99719addc735c801259f23ad2f221db8aee360/client.go#L155

2. The other issue, I'm not sure why sometimes the path is wrong and set to `mydrillbit` instead of `/drill/mydrillbit`. 

https://github.com/factset/go-drill/blob/eb99719addc735c801259f23ad2f221db8aee360/zk_handler.go#L76

This causes the connection to error ("invalid path") but it seems `z.Err` is never really checked. I'm not sure where this should be checked though.

https://github.com/factset/go-drill/blob/eb99719addc735c801259f23ad2f221db8aee360/zk_handler.go#L78

This PR fixes these, though maybe not elegantly.